### PR TITLE
Add "jl" for JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ See also: [Grep and Sed Equivalent for XML Command Line Processing](http://stack
 |---------------|-------------|
 | [fx](https://github.com/antonmedv/fx) | Run arbitrary JavaScript on JSON input. Standalone binaries available. |
 | [gron](https://github.com/tomnomnom/gron) | Convert JSON to and from flat, greppable lists of "path=value" statements. |
+| [jl](https://github.com/chrisdone/jl) | Query and manipulate JSON using a tiny functional language. |
 | [jo](https://github.com/jpmens/jo) | Create JSON objects from the shell. |
 | [jp](https://github.com/jmespath/jp) | [JMESPath](http://jmespath.org/) | 
 | [jq](http://stedolan.github.io/jq/manual/) | Create and manipulate JSON with a functional (as in "functional programming") [DSL](https://en.wikipedia.org/wiki/Domain-specific_language). Can convert JSON to other formats. |


### PR DESCRIPTION
I haven't actually used `jl` yet. What I do have is some messy browser bookmarks for JSON-related tools, that I'd like to delete and just consult your nice repo instead!