### PR TITLE
Add firebird/isql to single-file-databases section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ With a format converter like Remarshal (below) you can use [JSON](#json) tools t
 
 | Name and link | Description | File format |
 |---------------|-------------|-------------|
+| [Firebird](https://firebirdsql.org/) | Firebird is a FOSS database that can be used from a single file, like SQLite. "isql is a program that allows the user to issue arbitrary SQL commands". | Binary |
 | [GNU Recutils](http://www.gnu.org/software/recutils/) | "[A] set of tools and libraries to access human-editable, plain text databases called recfiles." | Text-based, roughly "key: value" |
 | [SDB](https://github.com/radare/sdb) | "[A] simple string key/value database based on djb's cdb disk storage and supports JSON and arrays introspection." | Binary |
 | [sqlite3(1)](https://www.sqlite.org/cli.html) | "[A] simple command-line utility [...] that allows the user to manually enter and execute SQL statements against an SQLite database." | Binary |


### PR DESCRIPTION
Hi,

Firebird is a FOSS database that can be used from a single file, like SQLite. `isql` is the command-line tool for using it.

This PR adds Firebird/isql into the single-file-databases section, in alphabetical order.