### PR TITLE
Update URL and text description for eBay's TSV utilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Awk is a POSIX-standard command line tool and programming language for processin
 | [pawk](https://github.com/alecthomas/pawk) | Process text with Awk-like patterns, but Python code. |
 | [rows](https://github.com/turicas/rows) | A Python library with a [CLI](http://turicas.info/rows/command-line-interface.html). Convert between a number of [file formats](http://turicas.info/rows/plugins.html) for tabular data: CSV, XLS, XLSX, ODS, and others. Query the data (via SQLite). Combine tables. Generate schemas. |
 | [tab](http://tkatchev.bitbucket.io/tab/) | A non-Turing-complete statically typed programming language for data processing. An alternative to Awk. |
-| [eBay's TSV utilities](https://ebay.github.io/tsv-utils-dlang/) | Filter, summarize, join, and perform other operations on TSV files. Written in D. |
+| [eBay's TSV utilities](https://github.com/eBay/tsv-utils-dlang) | Filtering, statistics, sampling, joins and other operations on TSV files. High performance, especially good for large datasets. Written in D. |
 | [VisiData](https://github.com/saulpw/visidata) | Explore interactively data in TSV, CSV, XLS, XLSX, HDF5, JSON, and [other formats](http://visidata.org/man/#loaders). [Introduction](https://jsvine.github.io/intro-to-visidata/). |
 | [xsv](https://github.com/BurntSushi/xsv) | Index, slice, analyze, split, and join CSV files. |
 


### PR DESCRIPTION
This changes the link for eBay's TSV utilities from the github pages URL to the main repository URL. There is an issue with the github pages URL, currently it 404s. Not clear when it'll be fixed (not in my control). So, link to the main repo instead. I also updated the text description.