### PR TITLE
Change eBay TSV Utilities URL after repository rename.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Awk is a POSIX-standard command line tool and programming language for processin
 | [pawk](https://github.com/alecthomas/pawk) | Process text with Awk-like patterns, but Python code. |
 | [rows](https://github.com/turicas/rows) | A Python library with a [CLI](http://turicas.info/rows/command-line-interface.html). Convert between a number of [file formats](http://turicas.info/rows/plugins.html) for tabular data: CSV, XLS, XLSX, ODS, and others. Query the data (via SQLite). Combine tables. Generate schemas. |
 | [tab](http://tkatchev.bitbucket.io/tab/) | A non-Turing-complete statically typed programming language for data processing. An alternative to Awk. |
-| [eBay's TSV utilities](https://github.com/eBay/tsv-utils-dlang) | Filtering, statistics, sampling, joins and other operations on TSV files. High performance, especially good for large datasets. Written in D. |
+| [eBay's TSV utilities](https://github.com/eBay/tsv-utils) | Filtering, statistics, sampling, joins and other operations on TSV files. High performance, especially good for large datasets. Written in D. |
 | [VisiData](https://github.com/saulpw/visidata) | Explore interactively data in TSV, CSV, XLS, XLSX, HDF5, JSON, and [other formats](http://visidata.org/man/#loaders). [Introduction](https://jsvine.github.io/intro-to-visidata/). |
 | [xsv](https://github.com/BurntSushi/xsv) | Index, slice, analyze, split, and join CSV files. |
 


### PR DESCRIPTION
I renamed the TSV Utilities repository from eBay/tsv-utils-dlang to eBay/tsv-utils. This PR updates the URL to point to the new repo. It's a low priority change as the old URL will continue to be redirected to the new address.