### PR TITLE
added clconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ See the [big comparison table](sql-based.md).  It covers
 
 | Name and link | Description |
 |---------------|-------------|
+| [clconf](https://github.com/pastdev/clconf) | A utility for merging multiple config files and extracting values using a path string. clconf is both a library, and a command line application. Supports JSON and YAML. |
 | [dasel](https://github.com/TomWright/dasel) | Query and update data structures from the command line.  Comparable to jq/yq but supports JSON, TOML, YAML, and XML.  Static binaries available for releases. |
 | [fx](https://github.com/antonmedv/fx) | Run arbitrary JavaScript on JSON input.  Standalone binaries available. |
 | [gojq](https://github.com/itchyny/gojq) | A pure Go implementation of jq (see below).  Supports YAML input and output. |
@@ -185,6 +186,7 @@ With a format converter like Remarshal (below) you can use [JSON](#json) tools t
 
 | Name and link | Description |
 |---------------|-------------|
+| [clconf](https://github.com/pastdev/clconf) | A utility for merging multiple config files and extracting values using a path string. clconf is both a library, and a command line application. Supports JSON and YAML. |
 | [dasel](https://github.com/TomWright/dasel) | Supports TOML and YAML.  See the [JSON section](#json). |
 | [gojq](https://github.com/itchyny/gojq) | Supports YAML.  See the [JSON section](#json). |
 | [Mario](https://github.com/python-mario/mario) | Supports YAML.  See the [JSON section](#json). |


### PR DESCRIPTION
Added [clconf](https://github.com/pastdev/clconf#clconf) to the `README.md`. I know that [there's a `sql-based.csv`](https://github.com/dbohdan/structured-text-tools/pull/92#issuecomment-627980444), but I didn't see one for `yaml` and `json`. Hope this is the right change.