### PR TITLE
Add `dotenvx`

### DIFF
--- a/README.md.jinja
+++ b/README.md.jinja
@@ -20,6 +20,7 @@ The following is a list of text-based file formats and command-line tools for ma
 - [YAML](#yaml)
 - [Configuration files](#configuration-files)
   - [/etc/hosts](#etchosts)
+  - [.env](#env)
   - [INI](#ini)
   - [Multiple formats](#multiple-formats)
 - [Log files](#log-files)
@@ -128,6 +129,10 @@ With a format converter like Remarshal you can use [JSON](#json) tools to proces
 ### INI
 
 {{ items("ini") }}
+
+### .env
+
+{{ items("env") }}
 
 ### Multiple formats
 

--- a/data/projects.toml
+++ b/data/projects.toml
@@ -648,6 +648,15 @@ Platform = "Free/Net/OpenBSD, Linux, macOS, Windows"
 License = "MIT"
 Description = "Query and transform data with the Nushell language."
 
+# .env
+
+[dotenvx]
+url = "https://github.com/dotenvx/dotenvx"
+Platform = "POSIX, Windows"
+License = "BSD-3-Clause"
+Description = "A CLI tool to manipulate, parse, and inject .env files as environment variables."
+tags = ["env"]
+
 # Templating for structured text
 
 [CUE]


### PR DESCRIPTION
> dotenvx is a command-line tool and node library for manipulating, parsing, and injecting .env files as environment variables.

1. Added a new section above `ini` called `.env` - a slightly different format than `ini` and popular with web developers.
2. Added `dotenvx` tagged to that section.

Thanks for a great resource!