### PR TITLE
Add Agentsor File Contracts

### DIFF
--- a/data/projects.toml
+++ b/data/projects.toml
@@ -3,6 +3,11 @@ url = "https://www.thegeekstuff.com/2011/06/awk-nawk-gawk/"
 descr = "A comparison of features present in different implementations."
 tags = ["awk"]
 
+["Agentsor File Contracts"]
+url = "https://github.com/linkoinsight/agentsor-file"
+descr = "Validate completed CSV and Parquet files against a TOML contract for schema, types, row and byte bounds, and freshness."
+tags = ["csv"]
+
 [argrelay]
 url = "https://github.com/argrelay/argrelay"
 descr = "Implement tab completion for commands in Bash based on search of indexed data through a background server."


### PR DESCRIPTION
## What changed

Adds Agentsor File Contracts to the CSV tools list. It is an MIT-licensed command-line tool for validating completed CSV and Parquet files against a TOML contract.

Disclosure: I maintain the submitted project.

## Why it fits

The CSV reader supports standard field quoting through PyArrow and the tool validates schema, types, row and byte bounds, and optional freshness.

## Validation

- Rendered the README successfully from `data/projects.toml`
- `git diff --check` passes